### PR TITLE
update robolectric to 2.4

### DIFF
--- a/WorkingOn-robolectricTest/build.gradle
+++ b/WorkingOn-robolectricTest/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    compile ('org.robolectric:robolectric:2.3') {
+    compile ('org.robolectric:robolectric:2.4') {
         exclude group:"com.android.support"
     }
     compile 'junit:junit:4.11'


### PR DESCRIPTION
I was getting groovy "to invoke method 'performCreate' with arguments [null]" - errors,  because we are using new google play services in the material branch (v 6.5+), I think....

So i tried changing it to 2.4. And now the groovy tests are working locally. But is it safe to change to 2.4 yet? Will it break other stuff?